### PR TITLE
feat: BuilderCodec DSL

### DIFF
--- a/example/src/main/kotlin/io/github/hytalekt/kytale/example/codec/GameConfigCodec.kt
+++ b/example/src/main/kotlin/io/github/hytalekt/kytale/example/codec/GameConfigCodec.kt
@@ -1,0 +1,53 @@
+package io.github.hytalekt.kytale.example.codec
+
+import com.hypixel.hytale.codec.Codec
+import io.github.hytalekt.kytale.codec.buildCodec
+
+data class GameConfig(
+    var maxPlayers: Int = 10,
+    var gameMode: String = "default",
+    var spawnProtection: Boolean = true,
+    var customRules: String = "",
+)
+
+val GameConfigCodec =
+    buildCodec(::GameConfig) {
+        documentation = "Game configuration with inheritance support"
+
+        addField("MaxPlayers", Codec.INTEGER) {
+            documentation = "Maximum number of players allowed"
+            setter { maxPlayers = it }
+            getter { _ -> maxPlayers }
+            inherit { parent, _ ->
+                maxPlayers = parent.maxPlayers
+            }
+        }
+
+        addField("GameMode", Codec.STRING) {
+            documentation = "The game mode identifier"
+            setter { gameMode = it }
+            getter { _ -> gameMode }
+            inherit { parent, _ ->
+                gameMode = parent.gameMode
+            }
+        }
+
+        addField("SpawnProtection", Codec.BOOLEAN) {
+            documentation = "Whether spawn protection is enabled"
+            setter { spawnProtection = it }
+            getter { _ -> spawnProtection }
+            inherit { parent, _ ->
+                spawnProtection = parent.spawnProtection
+            }
+        }
+
+        addField("CustomRules", Codec.STRING) {
+            documentation = "Custom game rules (not inherited)"
+            setter { customRules = it }
+            getter { _ -> customRules }
+        }
+
+        afterDecode {
+            require(maxPlayers > 0) { "MaxPlayers must be positive" }
+        }
+    }

--- a/example/src/main/kotlin/io/github/hytalekt/kytale/example/codec/ItemStackCodec.kt
+++ b/example/src/main/kotlin/io/github/hytalekt/kytale/example/codec/ItemStackCodec.kt
@@ -1,0 +1,75 @@
+package io.github.hytalekt.kytale.example.codec
+
+import com.hypixel.hytale.codec.Codec
+import com.hypixel.hytale.codec.schema.SchemaContext
+import com.hypixel.hytale.codec.schema.config.Schema
+import com.hypixel.hytale.codec.validation.ValidationResults
+import com.hypixel.hytale.codec.validation.Validator
+import io.github.hytalekt.kytale.codec.buildCodec
+
+data class ItemStack(
+    var itemId: String = "",
+    var count: Int = 1,
+    var damage: Int = 0,
+    var customName: String = "",
+)
+
+private object ItemCountValidator : Validator<Int> {
+    override fun accept(
+        value: Int,
+        results: ValidationResults,
+    ) {
+        if (value < 1) {
+            results.fail("Item count must be at least 1, got $value")
+        }
+        if (value > 64) {
+            results.warn("Item count exceeds typical max of 64, got $value")
+        }
+    }
+
+    override fun updateSchema(
+        ctx: SchemaContext,
+        schema: Schema,
+    ) {}
+}
+
+val ItemStackCodec =
+    buildCodec(::ItemStack) {
+        documentation = "Represents a stack of items in an inventory"
+        versioned()
+        codecVersion(version = 3, minVersion = 1)
+
+        addField("ItemId", Codec.STRING) {
+            documentation = "The item type identifier"
+            setter { itemId = it }
+            getter { _ -> itemId }
+        }
+
+        addField("Count", Codec.INTEGER) {
+            documentation = "Number of items in the stack (1-64)"
+            setter { count = it }
+            getter { _ -> count }
+            addValidator(ItemCountValidator)
+        }
+
+        addField("Damage", Codec.INTEGER) {
+            documentation = "Damage/durability value (added in v2)"
+            setter { damage, extraInfo ->
+                // Only set damage if version >= 2, otherwise use default
+                if (extraInfo.version >= 2) {
+                    this.damage = damage
+                }
+            }
+            getter { _ -> damage }
+        }
+
+        addField("CustomName", Codec.STRING) {
+            documentation = "Custom display name, empty if not set (added in v3)"
+            setter { name, extraInfo ->
+                if (extraInfo.version >= 3) {
+                    customName = name
+                }
+            }
+            getter { _ -> customName }
+        }
+    }

--- a/example/src/main/kotlin/io/github/hytalekt/kytale/example/codec/PlayerDataCodec.kt
+++ b/example/src/main/kotlin/io/github/hytalekt/kytale/example/codec/PlayerDataCodec.kt
@@ -1,0 +1,40 @@
+package io.github.hytalekt.kytale.example.codec
+
+import com.hypixel.hytale.codec.Codec
+import io.github.hytalekt.kytale.codec.buildCodec
+
+data class PlayerData(
+    var username: String = "",
+    var level: Int = 1,
+    var experience: Double = 0.0,
+    var isOnline: Boolean = false,
+)
+
+val PlayerDataCodec =
+    buildCodec(::PlayerData) {
+        documentation = "Stores basic player information"
+
+        addField("Username", Codec.STRING) {
+            documentation = "The player's display name"
+            setter { username = it }
+            getter { _ -> username }
+        }
+
+        addField("Level", Codec.INTEGER) {
+            documentation = "The player's current level"
+            setter { level = it }
+            getter { _ -> level }
+        }
+
+        addField("Experience", Codec.DOUBLE) {
+            documentation = "Total experience points"
+            setter { experience = it }
+            getter { _ -> experience }
+        }
+
+        addField("Online", Codec.BOOLEAN) {
+            documentation = "Whether the player is currently online"
+            setter { isOnline = it }
+            getter { _ -> isOnline }
+        }
+    }

--- a/src/main/kotlin/io/github/hytalekt/kytale/codec/CodecBuilder.kt
+++ b/src/main/kotlin/io/github/hytalekt/kytale/codec/CodecBuilder.kt
@@ -1,0 +1,103 @@
+@file:Suppress("NOTHING_TO_INLINE")
+
+package io.github.hytalekt.kytale.codec
+
+import com.hypixel.hytale.codec.Codec
+import com.hypixel.hytale.codec.KeyedCodec
+import com.hypixel.hytale.codec.builder.BuilderCodec
+import com.hypixel.hytale.codec.builder.BuilderField
+import com.hypixel.hytale.codec.schema.metadata.Metadata
+
+@CodecDsl
+@JvmInline
+value class CodecBuilder<T>(
+    val inner: BuilderCodec.Builder<T>,
+) {
+    /**
+     * Sets the documentation for this codec
+     *
+     * This is a write-only property. The getter throws [UnsupportedOperationException]
+     * because the underlying codec builder API does not support reading documentation back.
+     *
+     * @throws UnsupportedOperationException when attempting to read the documentation value
+     */
+    var documentation: String
+        get() = throw UnsupportedOperationException("Documentation is write-only and cannot be read")
+        set(value) {
+            inner.documentation(value)
+        }
+
+    /**
+     * Add a field to the codec with the given keyed codec
+     *
+     * @param F The type of the field
+     * @param codec The [KeyedCodec] that defines the field's key and codec
+     * @param block A lambda to configure the field using [FieldBuilder]
+     *
+     * @return The built field builder
+     */
+    inline fun <F> addField(
+        codec: KeyedCodec<F>,
+        block: FieldBuilder<T, F>.() -> Unit,
+    ): BuilderField.FieldBuilder<T, F, BuilderCodec.Builder<T>> = FieldBuilder<T, F>().apply(block).build(inner, codec)
+
+    /**
+     * Add a field to the codec with a string key and codec
+     *
+     * @param F The type of the field
+     * @param field The field name/key
+     * @param codec The [Codec] for encoding/decoding the field
+     * @param block A lambda to configure the field using [FieldBuilder]
+     *
+     * @return The built field builder
+     */
+    inline fun <F> addField(
+        field: String,
+        codec: Codec<F>,
+        block: FieldBuilder<T, F>.() -> Unit,
+    ): BuilderField.FieldBuilder<T, F, BuilderCodec.Builder<T>> = addField(KeyedCodec(field, codec), block)
+
+    /**
+     * Defines an `afterDecode` callback that is invoked after the codec finishes decoding
+     *
+     * @param receiver A lambda that will be invoked with the decoded object
+     *
+     * @see com.hypixel.hytale.codec.builder.BuilderCodec.Builder.afterDecode
+     */
+    fun afterDecode(receiver: T.() -> Unit) {
+        inner.afterDecode(receiver)
+    }
+
+    /**
+     * Adds a piece of metadata to the codec
+     *
+     * @param meta The [Metadata] to add
+     *
+     * @see com.hypixel.hytale.codec.schema.metadata.Metadata
+     */
+    fun addMetadata(meta: Metadata) {
+        inner.metadata(meta)
+    }
+
+    /**
+     * Sets the current codec version and minimal required codec version
+     *
+     * @param version The current version of the codec
+     * @param minVersion The minimum version that this codec can decode. Defaults to 0
+     */
+    fun codecVersion(
+        version: Int,
+        minVersion: Int = 0,
+    ) {
+        inner.codecVersion(minVersion, version)
+    }
+
+    /**
+     * Enables the `versioned` flag on the codec to indicate it supports versioning
+     *
+     * @see codecVersion
+     */
+    fun versioned() {
+        inner.versioned()
+    }
+}

--- a/src/main/kotlin/io/github/hytalekt/kytale/codec/CodecBuilder.kt
+++ b/src/main/kotlin/io/github/hytalekt/kytale/codec/CodecBuilder.kt
@@ -33,13 +33,13 @@ value class CodecBuilder<T>(
      * @param F The type of the field
      * @param codec The [KeyedCodec] that defines the field's key and codec
      * @param block A lambda to configure the field using [FieldBuilder]
-     *
-     * @return The built field builder
      */
     inline fun <F> addField(
         codec: KeyedCodec<F>,
         block: FieldBuilder<T, F>.() -> Unit,
-    ): BuilderField.FieldBuilder<T, F, BuilderCodec.Builder<T>> = FieldBuilder<T, F>().apply(block).build(inner, codec)
+    ) {
+        FieldBuilder<T, F>().apply(block).build(inner, codec).add()
+    }
 
     /**
      * Add a field to the codec with a string key and codec
@@ -48,14 +48,14 @@ value class CodecBuilder<T>(
      * @param field The field name/key
      * @param codec The [Codec] for encoding/decoding the field
      * @param block A lambda to configure the field using [FieldBuilder]
-     *
-     * @return The built field builder
      */
     inline fun <F> addField(
         field: String,
         codec: Codec<F>,
         block: FieldBuilder<T, F>.() -> Unit,
-    ): BuilderField.FieldBuilder<T, F, BuilderCodec.Builder<T>> = addField(KeyedCodec(field, codec), block)
+    ) {
+        addField(KeyedCodec(field, codec), block)
+    }
 
     /**
      * Defines an `afterDecode` callback that is invoked after the codec finishes decoding

--- a/src/main/kotlin/io/github/hytalekt/kytale/codec/CodecDsl.kt
+++ b/src/main/kotlin/io/github/hytalekt/kytale/codec/CodecDsl.kt
@@ -1,0 +1,50 @@
+package io.github.hytalekt.kytale.codec
+
+import com.hypixel.hytale.codec.builder.BuilderCodec
+import java.util.function.Supplier
+
+@DslMarker
+@Target(AnnotationTarget.CLASS, AnnotationTarget.TYPE, AnnotationTarget.FUNCTION, AnnotationTarget.PROPERTY, AnnotationTarget.FIELD)
+annotation class CodecDsl
+
+/**
+ * DSL for [BuilderCodec]
+ *
+ * Example usage:
+ *
+ *     buildCodec(::ExampleData) {
+ *         versioned()
+ *
+ *         documentation =
+ *             """
+ *             Example documentation
+ *             """.trimIndent()
+ *
+ *         addField("Index", Codec.INTEGER) {
+ *             documentation = "The index"
+ *
+ *             setter { this.index = it }
+ *             getter { this.index }
+ *         }
+ *
+ *         addField("Message", Codec.STRING) {
+ *             documentation = "The message"
+ *
+ *             setter { this.message = it }
+ *             getter { this.message }
+ *         }
+ *     }
+ *
+ * @param T The type to be encoded/decoded
+ * @param supplier A supplier function that creates new instances of type T (e.g., `::ClassName`)
+ * @param block A lambda with [CodecBuilder] receiver to configure the codec
+ *
+ * @return The built [BuilderCodec] for the type T
+ *
+ * @see CodecBuilder
+ * @see FieldBuilder
+ */
+inline fun <reified T> buildCodec(
+    supplier: Supplier<T>,
+    block: @CodecDsl CodecBuilder<T>.() -> Unit,
+): BuilderCodec<T?> = CodecBuilder<T>(BuilderCodec.builder(T::class.java, supplier)).apply(block).inner.build()

--- a/src/main/kotlin/io/github/hytalekt/kytale/codec/FieldBuilder.kt
+++ b/src/main/kotlin/io/github/hytalekt/kytale/codec/FieldBuilder.kt
@@ -1,0 +1,143 @@
+package io.github.hytalekt.kytale.codec
+
+import com.hypixel.hytale.codec.ExtraInfo
+import com.hypixel.hytale.codec.KeyedCodec
+import com.hypixel.hytale.codec.builder.BuilderCodec
+import com.hypixel.hytale.codec.builder.BuilderField
+import com.hypixel.hytale.codec.schema.metadata.Metadata
+import com.hypixel.hytale.codec.validation.LateValidator
+import com.hypixel.hytale.codec.validation.Validator
+import java.util.function.Supplier
+import kotlin.collections.addAll
+
+private typealias Setter<T, F> = T.(F, ExtraInfo) -> Unit
+
+private typealias Getter<T, F> = T.(ExtraInfo) -> F
+
+private typealias Inherit<T> = T.(T, ExtraInfo) -> Unit
+
+/**
+ * A DSL builder for configuring individual codec fields
+ *
+ * Provides methods to set getters, setters, validators, metadata, and documentation for a field.
+ * Typically used within the [CodecBuilder.addField] lambda block.
+ *
+ * @param T The type being encoded/decoded
+ * @param F The type of the field
+ * @see CodecBuilder.addField
+ */
+@CodecDsl
+data class FieldBuilder<T, F>(
+    /** The setter function for this field. Assigns the decoded value to the object. */
+    var setter: Setter<T, F>? = null,
+    /** The getter function for this field. Retrieves the value from the object for encoding. */
+    var getter: Getter<T, F>? = null,
+    /** An optional inherit function for this field. */
+    var inherit: Inherit<T>? = null,
+    /** Documentation for this field. */
+    var documentation: String = "",
+    /** List of validators to apply to this field. */
+    val validators: MutableList<Validator<F>> = mutableListOf(),
+    /** List of late validators to apply to this field. */
+    val lateValidators: MutableList<Supplier<LateValidator<in F>>> = mutableListOf(),
+    /** List of metadata associated with this field. */
+    val metadata: MutableList<Metadata> = mutableListOf(),
+) {
+    /**
+     * Sets the setter function without ExtraInfo
+     *
+     * @param setter A lambda that receives the field value and assigns it to the object
+     */
+    inline fun setter(crossinline setter: T.(F) -> Unit) {
+        this.setter { value, _ -> setter(value) }
+    }
+
+    /**
+     * Sets the setter function with ExtraInfo
+     *
+     * @param setter A [Setter] lambda that can access ExtraInfo
+     */
+    fun setter(setter: Setter<T, F>) {
+        this.setter = setter
+    }
+
+    /**
+     * Sets the getter function
+     *
+     * @param getter A [Getter] lambda that retrieves the field value from the object
+     */
+    fun getter(getter: Getter<T, F>) {
+        this.getter = getter
+    }
+
+    /**
+     * Sets the inherit function
+     *
+     * @param inherit An [Inherit] lambda for inheritance behavior
+     */
+    fun inherit(inherit: Inherit<T>) {
+        this.inherit = inherit
+    }
+
+    /**
+     * Add validators for this field
+     *
+     * @param validator A [Validator] instance
+     *
+     * @see com.hypixel.hytale.codec.validation.Validator
+     */
+    fun addValidator(validator: Validator<F>) {
+        this.validators.add(validator)
+    }
+
+    /**
+     * Add late validators for this field
+     *
+     * Late validators are evaluated after all fields have been decoded.
+     *
+     * @param validator A supplier that provides a [LateValidator] instance
+     *
+     * @see com.hypixel.hytale.codec.validation.LateValidator
+     */
+    fun addLateValidator(validator: @CodecDsl Supplier<LateValidator<in F>>) {
+        lateValidators.add(validator)
+    }
+
+    /**
+     * Add metadata for this field
+     *
+     * @param metadata A [Metadata] instance to add to this field
+     *
+     * @see com.hypixel.hytale.codec.schema.metadata.Metadata
+     */
+    fun addMetadata(metadata: Metadata) {
+        this.metadata.add(metadata)
+    }
+
+    /**
+     * Builds the field with the given parent builder and keyed codec
+     *
+     * @param B The type of the parent builder
+     * @param parent The parent codec builder
+     * @param codec The keyed codec for this field
+     *
+     * @return The built [BuilderField.FieldBuilder]
+     */
+    fun <B : BuilderCodec.BuilderBase<T, B>> build(
+        parent: B,
+        codec: KeyedCodec<F>,
+    ): BuilderField.FieldBuilder<T, F, B> =
+        BuilderField
+            .FieldBuilder(
+                parent,
+                codec,
+                setter,
+                getter,
+                inherit,
+            ).also {
+                validators.forEach(it::addValidator)
+                lateValidators.forEach(it::addValidatorLate)
+                metadata.forEach(it::metadata)
+                it.documentation(documentation)
+            }
+}

--- a/src/test/kotlin/io/github/hytalekt/kytale/codec/CodecBuilderTest.kt
+++ b/src/test/kotlin/io/github/hytalekt/kytale/codec/CodecBuilderTest.kt
@@ -1,0 +1,155 @@
+package io.github.hytalekt.kytale.codec
+
+import com.hypixel.hytale.codec.Codec
+import com.hypixel.hytale.codec.EmptyExtraInfo
+import com.hypixel.hytale.codec.KeyedCodec
+import com.hypixel.hytale.codec.builder.BuilderCodec
+import com.hypixel.hytale.codec.schema.SchemaContext
+import com.hypixel.hytale.codec.schema.config.Schema
+import com.hypixel.hytale.codec.validation.ValidationResults
+import com.hypixel.hytale.codec.validation.Validator
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import org.bson.BsonDocument
+import org.bson.BsonInt32
+import org.bson.BsonString
+
+private data class Foo(
+    var name: String = "",
+    var value: Int = 0,
+)
+
+class CodecBuilderTest :
+    FunSpec({
+        test("DSL builds equivalent codec to Java builder") {
+            val dslCodec =
+                buildCodec(::Foo) {
+                    addField("Name", Codec.STRING) {
+                        setter { name = it }
+                        getter { _ -> name }
+                    }
+                    addField("Value", Codec.INTEGER) {
+                        setter { value = it }
+                        getter { _ -> value }
+                    }
+                }
+
+            val javaCodec =
+                BuilderCodec
+                    .builder(Foo::class.java, ::Foo)
+                    .append(KeyedCodec("Name", Codec.STRING), { f, n -> f.name = n }, { it.name })
+                    .add()
+                    .append(KeyedCodec("Value", Codec.INTEGER), { f, v -> f.value = v }, { it.value })
+                    .add()
+                    .build()
+
+            val testFoo = Foo("test", 42)
+            dslCodec.encode(testFoo, EmptyExtraInfo.EMPTY) shouldBe javaCodec.encode(testFoo, EmptyExtraInfo.EMPTY)
+        }
+
+        test("ExtraInfo is passed to setter and getter") {
+            var setterVersion = -1
+            var getterVersion = -1
+
+            val codec =
+                buildCodec(::Foo) {
+                    versioned()
+                    codecVersion(5, 0)
+                    addField("Name", Codec.STRING) {
+                        setter { name = it }
+                        getter { _ -> name }
+                    }
+                    addField("Value", Codec.INTEGER) {
+                        setter { v, extra -> setterVersion = extra.version; value = v }
+                        getter { extra -> getterVersion = extra.version; value }
+                    }
+                }
+
+            codec.encode(Foo("test", 99), EmptyExtraInfo.EMPTY)
+            getterVersion shouldBe 5
+
+            val doc = BsonDocument().apply {
+                put("Version", BsonInt32(3))
+                put("Name", BsonString("test"))
+                put("Value", BsonInt32(42))
+            }
+            codec.decode(doc, EmptyExtraInfo.EMPTY)
+            setterVersion shouldBe 3
+        }
+
+        test("afterDecode callback is invoked") {
+            var called = false
+            val codec =
+                buildCodec(::Foo) {
+                    addField("Name", Codec.STRING) {
+                        setter { name = it }
+                        getter { _ -> name }
+                    }
+                    afterDecode { called = true }
+                }
+
+            codec.decode(BsonDocument().apply { put("Name", BsonString("test")) }, EmptyExtraInfo.EMPTY)
+            called shouldBe true
+        }
+
+        test("addField with KeyedCodec and field documentation") {
+            val codec =
+                buildCodec(::Foo) {
+                    documentation = "Codec-level documentation"
+                    addField(KeyedCodec("Name", Codec.STRING)) {
+                        documentation = "Field-level documentation"
+                        setter { name = it }
+                        getter { _ -> name }
+                    }
+                }
+
+            val decoded = codec.decode(BsonDocument().apply { put("Name", BsonString("test")) }, EmptyExtraInfo.EMPTY)!!
+            decoded.name shouldBe "test"
+        }
+
+        test("inherit function copies value from parent") {
+            var inheritCalled = false
+            val codec =
+                buildCodec(::Foo) {
+                    addField("Name", Codec.STRING) {
+                        setter { name = it }
+                        getter { _ -> name }
+                        inherit { parent, _ ->
+                            inheritCalled = true
+                            name = parent.name
+                        }
+                    }
+                    addField("Value", Codec.INTEGER) {
+                        setter { value = it }
+                        getter { _ -> value }
+                    }
+                }
+
+            val parent = Foo("inherited", 100)
+            val child = codec.decodeAndInherit(BsonDocument().apply { put("Value", BsonInt32(50)) }, parent, EmptyExtraInfo.EMPTY)!!
+
+            inheritCalled shouldBe true
+            child.name shouldBe "inherited"
+            child.value shouldBe 50
+        }
+
+        test("addValidator is invoked during decode") {
+            var validatorCalled = false
+            val codec =
+                buildCodec(::Foo) {
+                    addField("Name", Codec.STRING) {
+                        setter { name = it }
+                        getter { _ -> name }
+                        addValidator(object : Validator<String> {
+                            override fun accept(value: String, results: ValidationResults) {
+                                validatorCalled = true
+                            }
+                            override fun updateSchema(ctx: SchemaContext, schema: Schema) {}
+                        })
+                    }
+                }
+
+            codec.decode(BsonDocument().apply { put("Name", BsonString("test")) }, EmptyExtraInfo.EMPTY)
+            validatorCalled shouldBe true
+        }
+    })


### PR DESCRIPTION
This PR implements a BuilderCodec DSL based on @Olypolyu's (see https://github.com/briarss/Kytale/pull/1)

### Implementation changes:
- Separated into multiple files
- CodecBuilder became a value class that wraps BuilderCodec.Builder<T>
- FieldBuilder is now a standalone data class instead of an inner class
- Removed some unnecessary functions
- Some things (e.g. BuilderCodec#documentation) now use property setter syntax instead

The DSL is similar with minor changes

Example (before):
```kt
buildCodec(::ArcioBaseComponent) {
    versioned()
    documentation {
        """
            Very long and through explanation on the behaviour of this component*
            You think this is amazing*
        """.trimIndent()
    }
   
    addField("NodeIndex", Codec.INTEGER) {
        setter { this.index = it }
        getter { this.index }
        documentation { "Index of the current node in the manathread network." }
    }

    addField("IO", ArrayCodec(ManathreadConnector.CODEC) { i -> arrayOfNulls<ManathreadConnector>(i) }) {
        setter { this.connectors = it.toMutableList() }
        getter { this.connectors.toTypedArray()}
        documentation { "List of connections to and from the current node." }
    }
}
 ```
 
 Example (after):
```kt
buildCodec(::ExampleData) {
    versioned()

    documentation =
        """
        Example documentation
        """.trimIndent()

    addField("Index", Codec.INTEGER) {
        documentation = "The index"

        setter { this.index = it }
        getter { this.index }
    }

    addField("Message", Codec.STRING) {
        documentation = "The message"

        setter { this.message = it }
        getter { this.message }
    }
}
 ```