### PR TITLE
feat: Hytale extensions

### DIFF
--- a/example/src/main/kotlin/io/github/hytalekt/kytale/example/ExamplePlugin.kt
+++ b/example/src/main/kotlin/io/github/hytalekt/kytale/example/ExamplePlugin.kt
@@ -1,8 +1,41 @@
 package io.github.hytalekt.kytale.example
 
+import com.hypixel.hytale.math.vector.Vector3d
+import com.hypixel.hytale.server.core.event.events.player.PlayerChatEvent
+import com.hypixel.hytale.server.core.event.events.player.PlayerConnectEvent
 import com.hypixel.hytale.server.core.plugin.JavaPlugin
 import com.hypixel.hytale.server.core.plugin.JavaPluginInit
+import io.github.hytalekt.kytale.ext.atInfoOrNull
+import io.github.hytalekt.kytale.ext.component1
+import io.github.hytalekt.kytale.ext.component2
+import io.github.hytalekt.kytale.ext.component3
+import io.github.hytalekt.kytale.ext.plus
+import io.github.hytalekt.kytale.ext.register
+import io.github.hytalekt.kytale.ext.registerAsyncUnhandled
+import io.github.hytalekt.kytale.ext.times
+import io.github.hytalekt.kytale.message.text
 
 class ExamplePlugin(
     init: JavaPluginInit,
-) : JavaPlugin(init)
+) : JavaPlugin(init) {
+    override fun start() {
+        eventRegistry.register<PlayerConnectEvent>(4) { event ->
+            event.playerRef.sendMessage(text("You are connected to the server!"))
+        }
+
+        eventRegistry.registerAsyncUnhandled<_, PlayerChatEvent> {
+            it.thenApply { event ->
+                event.sender.sendMessage(text("You sent a message!"))
+                event
+            }
+        }
+
+        logger.atInfoOrNull()?.log("Plugin started")
+
+        val pos = Vector3d(1.0, 2.0, 3.0)
+        val offset = Vector3d(10.0, 0.0, 10.0)
+        val newPos = pos + offset
+        val scaled = pos * 2.0
+        val (x, y, z) = newPos
+    }
+}

--- a/src/main/kotlin/io/github/hytalekt/kytale/ext/EventBusExt.kt
+++ b/src/main/kotlin/io/github/hytalekt/kytale/ext/EventBusExt.kt
@@ -5,8 +5,18 @@ import com.hypixel.hytale.event.EventBusRegistry
 import com.hypixel.hytale.event.IBaseEvent
 import com.hypixel.hytale.event.IEvent
 
+/**
+ * Reified version of [EventBus.getRegistry]
+ *
+ * @see com.hypixel.hytale.event.EventBus.getRegistry
+ */
 inline fun <KeyType, reified EventType : IBaseEvent<KeyType>> EventBus.getRegistry(): EventBusRegistry<KeyType, EventType, *> =
     getRegistry(EventType::class.java)
 
+/**
+ * Reified version of [EventBus.getSyncRegistry]
+ *
+ * @see com.hypixel.hytale.event.EventBus.getSyncRegistry
+ */
 inline fun <KeyType, reified EventType : IEvent<KeyType>> EventBus.getSyncRegistry(): EventBusRegistry<KeyType, EventType, *> =
     getSyncRegistry(EventType::class.java)

--- a/src/main/kotlin/io/github/hytalekt/kytale/ext/EventBusExt.kt
+++ b/src/main/kotlin/io/github/hytalekt/kytale/ext/EventBusExt.kt
@@ -1,0 +1,12 @@
+package io.github.hytalekt.kytale.ext
+
+import com.hypixel.hytale.event.EventBus
+import com.hypixel.hytale.event.EventBusRegistry
+import com.hypixel.hytale.event.IBaseEvent
+import com.hypixel.hytale.event.IEvent
+
+inline fun <KeyType, reified EventType : IBaseEvent<KeyType>> EventBus.getRegistry(): EventBusRegistry<KeyType, EventType, *> =
+    getRegistry(EventType::class.java)
+
+inline fun <KeyType, reified EventType : IEvent<KeyType>> EventBus.getSyncRegistry(): EventBusRegistry<KeyType, EventType, *> =
+    getSyncRegistry(EventType::class.java)

--- a/src/main/kotlin/io/github/hytalekt/kytale/ext/EventRegistryExt.kt
+++ b/src/main/kotlin/io/github/hytalekt/kytale/ext/EventRegistryExt.kt
@@ -9,119 +9,239 @@ import java.util.concurrent.CompletableFuture
 import java.util.function.Consumer
 import java.util.function.Function
 
+/**
+ * Reified version of [IEventRegistry.register]
+ *
+ * @see com.hypixel.hytale.event.IEventRegistry.register
+ */
 inline fun <reified EventType : IBaseEvent<Void>> IEventRegistry.register(
     consumer: Consumer<EventType>,
 ): EventRegistration<Void, EventType>? = register(EventType::class.java, consumer)
 
+/**
+ * Reified version of [IEventRegistry.register]
+ *
+ * @see com.hypixel.hytale.event.IEventRegistry.register
+ */
 inline fun <reified EventType : IBaseEvent<Void>> IEventRegistry.register(
     priority: EventPriority,
     consumer: Consumer<EventType>,
 ): EventRegistration<Void, EventType>? = register(priority, EventType::class.java, consumer)
 
+/**
+ * Reified version of [IEventRegistry.register]
+ *
+ * @see com.hypixel.hytale.event.IEventRegistry.register
+ */
 inline fun <reified EventType : IBaseEvent<Void>> IEventRegistry.register(
     priority: Short,
     consumer: Consumer<EventType>,
 ): EventRegistration<Void, EventType>? = register(priority, EventType::class.java, consumer)
 
+/**
+ * Reified version of [IEventRegistry.register]
+ *
+ * @see com.hypixel.hytale.event.IEventRegistry.register
+ */
 inline fun <KeyType : Any, reified EventType : IBaseEvent<KeyType>> IEventRegistry.register(
     key: KeyType,
     consumer: Consumer<EventType>,
 ): EventRegistration<KeyType, EventType>? = register(EventType::class.java, key, consumer)
 
+/**
+ * Reified version of [IEventRegistry.register]
+ *
+ * @see com.hypixel.hytale.event.IEventRegistry.register
+ */
 inline fun <KeyType : Any, reified EventType : IBaseEvent<KeyType>> IEventRegistry.register(
     priority: EventPriority,
     key: KeyType,
     consumer: Consumer<EventType>,
 ): EventRegistration<KeyType, EventType>? = register(priority, EventType::class.java, key, consumer)
 
+/**
+ * Reified version of [IEventRegistry.register]
+ *
+ * @see com.hypixel.hytale.event.IEventRegistry.register
+ */
 inline fun <KeyType : Any, reified EventType : IBaseEvent<KeyType>> IEventRegistry.register(
     priority: Short,
     key: KeyType,
     consumer: Consumer<EventType>,
 ): EventRegistration<KeyType, EventType>? = register(priority, EventType::class.java, key, consumer)
 
+/**
+ * Reified version of [IEventRegistry.registerAsync]
+ *
+ * @see com.hypixel.hytale.event.IEventRegistry.registerAsync
+ */
 inline fun <reified EventType : IAsyncEvent<Void>> IEventRegistry.registerAsync(
     handler: Function<CompletableFuture<EventType>, CompletableFuture<EventType>>,
 ): EventRegistration<Void, EventType>? = registerAsync(EventType::class.java, handler)
 
+/**
+ * Reified version of [IEventRegistry.registerAsync]
+ *
+ * @see com.hypixel.hytale.event.IEventRegistry.registerAsync
+ */
 inline fun <reified EventType : IAsyncEvent<Void>> IEventRegistry.registerAsync(
     priority: EventPriority,
     handler: Function<CompletableFuture<EventType>, CompletableFuture<EventType>>,
 ): EventRegistration<Void, EventType>? = registerAsync(priority, EventType::class.java, handler)
 
+/**
+ * Reified version of [IEventRegistry.registerAsync]
+ *
+ * @see com.hypixel.hytale.event.IEventRegistry.registerAsync
+ */
 inline fun <reified EventType : IAsyncEvent<Void>> IEventRegistry.registerAsync(
     priority: Short,
     handler: Function<CompletableFuture<EventType>, CompletableFuture<EventType>>,
 ): EventRegistration<Void, EventType>? = registerAsync(priority, EventType::class.java, handler)
 
+/**
+ * Reified version of [IEventRegistry.registerAsync]
+ *
+ * @see com.hypixel.hytale.event.IEventRegistry.registerAsync
+ */
 inline fun <KeyType : Any, reified EventType : IAsyncEvent<KeyType>> IEventRegistry.registerAsync(
     key: KeyType,
     handler: Function<CompletableFuture<EventType>, CompletableFuture<EventType>>,
 ): EventRegistration<KeyType, EventType>? = registerAsync(EventType::class.java, key, handler)
 
+/**
+ * Reified version of [IEventRegistry.registerAsync]
+ *
+ * @see com.hypixel.hytale.event.IEventRegistry.registerAsync
+ */
 inline fun <KeyType : Any, reified EventType : IAsyncEvent<KeyType>> IEventRegistry.registerAsync(
     priority: EventPriority,
     key: KeyType,
     handler: Function<CompletableFuture<EventType>, CompletableFuture<EventType>>,
 ): EventRegistration<KeyType, EventType>? = registerAsync(priority, EventType::class.java, key, handler)
 
+/**
+ * Reified version of [IEventRegistry.registerAsync]
+ *
+ * @see com.hypixel.hytale.event.IEventRegistry.registerAsync
+ */
 inline fun <KeyType : Any, reified EventType : IAsyncEvent<KeyType>> IEventRegistry.registerAsync(
     priority: Short,
     key: KeyType,
     handler: Function<CompletableFuture<EventType>, CompletableFuture<EventType>>,
 ): EventRegistration<KeyType, EventType>? = registerAsync(priority, EventType::class.java, key, handler)
 
+/**
+ * Reified version of [IEventRegistry.registerGlobal]
+ *
+ * @see com.hypixel.hytale.event.IEventRegistry.registerGlobal
+ */
 inline fun <KeyType, reified EventType : IBaseEvent<KeyType>> IEventRegistry.registerGlobal(
     consumer: Consumer<EventType>,
 ): EventRegistration<KeyType, EventType>? = registerGlobal(EventType::class.java, consumer)
 
+/**
+ * Reified version of [IEventRegistry.registerGlobal]
+ *
+ * @see com.hypixel.hytale.event.IEventRegistry.registerGlobal
+ */
 inline fun <KeyType, reified EventType : IBaseEvent<KeyType>> IEventRegistry.registerGlobal(
     priority: EventPriority,
     consumer: Consumer<EventType>,
 ): EventRegistration<KeyType, EventType>? = registerGlobal(priority, EventType::class.java, consumer)
 
+/**
+ * Reified version of [IEventRegistry.registerGlobal]
+ *
+ * @see com.hypixel.hytale.event.IEventRegistry.registerGlobal
+ */
 inline fun <KeyType, reified EventType : IBaseEvent<KeyType>> IEventRegistry.registerGlobal(
     priority: Short,
     consumer: Consumer<EventType>,
 ): EventRegistration<KeyType, EventType>? = registerGlobal(priority, EventType::class.java, consumer)
 
+/**
+ * Reified version of [IEventRegistry.registerAsyncGlobal]
+ *
+ * @see com.hypixel.hytale.event.IEventRegistry.registerAsyncGlobal
+ */
 inline fun <KeyType, reified EventType : IAsyncEvent<KeyType>> IEventRegistry.registerAsyncGlobal(
     handler: Function<CompletableFuture<EventType>, CompletableFuture<EventType>>,
 ): EventRegistration<KeyType, EventType>? = registerAsyncGlobal(EventType::class.java, handler)
 
+/**
+ * Reified version of [IEventRegistry.registerAsyncGlobal]
+ *
+ * @see com.hypixel.hytale.event.IEventRegistry.registerAsyncGlobal
+ */
 inline fun <KeyType, reified EventType : IAsyncEvent<KeyType>> IEventRegistry.registerAsyncGlobal(
     priority: EventPriority,
     handler: Function<CompletableFuture<EventType>, CompletableFuture<EventType>>,
 ): EventRegistration<KeyType, EventType>? = registerAsyncGlobal(priority, EventType::class.java, handler)
 
+/**
+ * Reified version of [IEventRegistry.registerAsyncGlobal]
+ *
+ * @see com.hypixel.hytale.event.IEventRegistry.registerAsyncGlobal
+ */
 inline fun <KeyType, reified EventType : IAsyncEvent<KeyType>> IEventRegistry.registerAsyncGlobal(
     priority: Short,
     handler: Function<CompletableFuture<EventType>, CompletableFuture<EventType>>,
 ): EventRegistration<KeyType, EventType>? = registerAsyncGlobal(priority, EventType::class.java, handler)
 
+/**
+ * Reified version of [IEventRegistry.registerUnhandled]
+ *
+ * @see com.hypixel.hytale.event.IEventRegistry.registerUnhandled
+ */
 inline fun <KeyType, reified EventType : IBaseEvent<KeyType>> IEventRegistry.registerUnhandled(
     consumer: Consumer<EventType>,
 ): EventRegistration<KeyType, EventType>? = registerUnhandled(EventType::class.java, consumer)
 
+/**
+ * Reified version of [IEventRegistry.registerUnhandled]
+ *
+ * @see com.hypixel.hytale.event.IEventRegistry.registerUnhandled
+ */
 inline fun <KeyType, reified EventType : IBaseEvent<KeyType>> IEventRegistry.registerUnhandled(
     priority: EventPriority,
     consumer: Consumer<EventType>,
 ): EventRegistration<KeyType, EventType>? = registerUnhandled(priority, EventType::class.java, consumer)
 
+/**
+ * Reified version of [IEventRegistry.registerUnhandled]
+ *
+ * @see com.hypixel.hytale.event.IEventRegistry.registerUnhandled
+ */
 inline fun <KeyType, reified EventType : IBaseEvent<KeyType>> IEventRegistry.registerUnhandled(
     priority: Short,
     consumer: Consumer<EventType>,
 ): EventRegistration<KeyType, EventType>? = registerUnhandled(priority, EventType::class.java, consumer)
 
+/**
+ * Reified version of [IEventRegistry.registerAsyncUnhandled]
+ *
+ * @see com.hypixel.hytale.event.IEventRegistry.registerAsyncUnhandled
+ */
 inline fun <KeyType, reified EventType : IAsyncEvent<KeyType>> IEventRegistry.registerAsyncUnhandled(
     handler: Function<CompletableFuture<EventType>, CompletableFuture<EventType>>,
 ): EventRegistration<KeyType, EventType>? = registerAsyncUnhandled(EventType::class.java, handler)
 
+/**
+ * Reified version of [IEventRegistry.registerAsyncUnhandled]
+ *
+ * @see com.hypixel.hytale.event.IEventRegistry.registerAsyncUnhandled
+ */
 inline fun <KeyType, reified EventType : IAsyncEvent<KeyType>> IEventRegistry.registerAsyncUnhandled(
     priority: EventPriority,
     handler: Function<CompletableFuture<EventType>, CompletableFuture<EventType>>,
 ): EventRegistration<KeyType, EventType>? = registerAsyncUnhandled(priority, EventType::class.java, handler)
 
+/**
+ * Reified version of [IEventRegistry.registerAsyncUnhandled]
+ *
+ * @see com.hypixel.hytale.event.IEventRegistry.registerAsyncUnhandled
+ */
 inline fun <KeyType, reified EventType : IAsyncEvent<KeyType>> IEventRegistry.registerAsyncUnhandled(
     priority: Short,
     handler: Function<CompletableFuture<EventType>, CompletableFuture<EventType>>,

--- a/src/main/kotlin/io/github/hytalekt/kytale/ext/EventRegistryExt.kt
+++ b/src/main/kotlin/io/github/hytalekt/kytale/ext/EventRegistryExt.kt
@@ -1,0 +1,128 @@
+package io.github.hytalekt.kytale.ext
+
+import com.hypixel.hytale.event.EventPriority
+import com.hypixel.hytale.event.EventRegistration
+import com.hypixel.hytale.event.IAsyncEvent
+import com.hypixel.hytale.event.IBaseEvent
+import com.hypixel.hytale.event.IEventRegistry
+import java.util.concurrent.CompletableFuture
+import java.util.function.Consumer
+import java.util.function.Function
+
+inline fun <reified EventType : IBaseEvent<Void>> IEventRegistry.register(
+    consumer: Consumer<EventType>,
+): EventRegistration<Void, EventType>? = register(EventType::class.java, consumer)
+
+inline fun <reified EventType : IBaseEvent<Void>> IEventRegistry.register(
+    priority: EventPriority,
+    consumer: Consumer<EventType>,
+): EventRegistration<Void, EventType>? = register(priority, EventType::class.java, consumer)
+
+inline fun <reified EventType : IBaseEvent<Void>> IEventRegistry.register(
+    priority: Short,
+    consumer: Consumer<EventType>,
+): EventRegistration<Void, EventType>? = register(priority, EventType::class.java, consumer)
+
+inline fun <KeyType : Any, reified EventType : IBaseEvent<KeyType>> IEventRegistry.register(
+    key: KeyType,
+    consumer: Consumer<EventType>,
+): EventRegistration<KeyType, EventType>? = register(EventType::class.java, key, consumer)
+
+inline fun <KeyType : Any, reified EventType : IBaseEvent<KeyType>> IEventRegistry.register(
+    priority: EventPriority,
+    key: KeyType,
+    consumer: Consumer<EventType>,
+): EventRegistration<KeyType, EventType>? = register(priority, EventType::class.java, key, consumer)
+
+inline fun <KeyType : Any, reified EventType : IBaseEvent<KeyType>> IEventRegistry.register(
+    priority: Short,
+    key: KeyType,
+    consumer: Consumer<EventType>,
+): EventRegistration<KeyType, EventType>? = register(priority, EventType::class.java, key, consumer)
+
+inline fun <reified EventType : IAsyncEvent<Void>> IEventRegistry.registerAsync(
+    handler: Function<CompletableFuture<EventType>, CompletableFuture<EventType>>,
+): EventRegistration<Void, EventType>? = registerAsync(EventType::class.java, handler)
+
+inline fun <reified EventType : IAsyncEvent<Void>> IEventRegistry.registerAsync(
+    priority: EventPriority,
+    handler: Function<CompletableFuture<EventType>, CompletableFuture<EventType>>,
+): EventRegistration<Void, EventType>? = registerAsync(priority, EventType::class.java, handler)
+
+inline fun <reified EventType : IAsyncEvent<Void>> IEventRegistry.registerAsync(
+    priority: Short,
+    handler: Function<CompletableFuture<EventType>, CompletableFuture<EventType>>,
+): EventRegistration<Void, EventType>? = registerAsync(priority, EventType::class.java, handler)
+
+inline fun <KeyType : Any, reified EventType : IAsyncEvent<KeyType>> IEventRegistry.registerAsync(
+    key: KeyType,
+    handler: Function<CompletableFuture<EventType>, CompletableFuture<EventType>>,
+): EventRegistration<KeyType, EventType>? = registerAsync(EventType::class.java, key, handler)
+
+inline fun <KeyType : Any, reified EventType : IAsyncEvent<KeyType>> IEventRegistry.registerAsync(
+    priority: EventPriority,
+    key: KeyType,
+    handler: Function<CompletableFuture<EventType>, CompletableFuture<EventType>>,
+): EventRegistration<KeyType, EventType>? = registerAsync(priority, EventType::class.java, key, handler)
+
+inline fun <KeyType : Any, reified EventType : IAsyncEvent<KeyType>> IEventRegistry.registerAsync(
+    priority: Short,
+    key: KeyType,
+    handler: Function<CompletableFuture<EventType>, CompletableFuture<EventType>>,
+): EventRegistration<KeyType, EventType>? = registerAsync(priority, EventType::class.java, key, handler)
+
+inline fun <KeyType, reified EventType : IBaseEvent<KeyType>> IEventRegistry.registerGlobal(
+    consumer: Consumer<EventType>,
+): EventRegistration<KeyType, EventType>? = registerGlobal(EventType::class.java, consumer)
+
+inline fun <KeyType, reified EventType : IBaseEvent<KeyType>> IEventRegistry.registerGlobal(
+    priority: EventPriority,
+    consumer: Consumer<EventType>,
+): EventRegistration<KeyType, EventType>? = registerGlobal(priority, EventType::class.java, consumer)
+
+inline fun <KeyType, reified EventType : IBaseEvent<KeyType>> IEventRegistry.registerGlobal(
+    priority: Short,
+    consumer: Consumer<EventType>,
+): EventRegistration<KeyType, EventType>? = registerGlobal(priority, EventType::class.java, consumer)
+
+inline fun <KeyType, reified EventType : IAsyncEvent<KeyType>> IEventRegistry.registerAsyncGlobal(
+    handler: Function<CompletableFuture<EventType>, CompletableFuture<EventType>>,
+): EventRegistration<KeyType, EventType>? = registerAsyncGlobal(EventType::class.java, handler)
+
+inline fun <KeyType, reified EventType : IAsyncEvent<KeyType>> IEventRegistry.registerAsyncGlobal(
+    priority: EventPriority,
+    handler: Function<CompletableFuture<EventType>, CompletableFuture<EventType>>,
+): EventRegistration<KeyType, EventType>? = registerAsyncGlobal(priority, EventType::class.java, handler)
+
+inline fun <KeyType, reified EventType : IAsyncEvent<KeyType>> IEventRegistry.registerAsyncGlobal(
+    priority: Short,
+    handler: Function<CompletableFuture<EventType>, CompletableFuture<EventType>>,
+): EventRegistration<KeyType, EventType>? = registerAsyncGlobal(priority, EventType::class.java, handler)
+
+inline fun <KeyType, reified EventType : IBaseEvent<KeyType>> IEventRegistry.registerUnhandled(
+    consumer: Consumer<EventType>,
+): EventRegistration<KeyType, EventType>? = registerUnhandled(EventType::class.java, consumer)
+
+inline fun <KeyType, reified EventType : IBaseEvent<KeyType>> IEventRegistry.registerUnhandled(
+    priority: EventPriority,
+    consumer: Consumer<EventType>,
+): EventRegistration<KeyType, EventType>? = registerUnhandled(priority, EventType::class.java, consumer)
+
+inline fun <KeyType, reified EventType : IBaseEvent<KeyType>> IEventRegistry.registerUnhandled(
+    priority: Short,
+    consumer: Consumer<EventType>,
+): EventRegistration<KeyType, EventType>? = registerUnhandled(priority, EventType::class.java, consumer)
+
+inline fun <KeyType, reified EventType : IAsyncEvent<KeyType>> IEventRegistry.registerAsyncUnhandled(
+    handler: Function<CompletableFuture<EventType>, CompletableFuture<EventType>>,
+): EventRegistration<KeyType, EventType>? = registerAsyncUnhandled(EventType::class.java, handler)
+
+inline fun <KeyType, reified EventType : IAsyncEvent<KeyType>> IEventRegistry.registerAsyncUnhandled(
+    priority: EventPriority,
+    handler: Function<CompletableFuture<EventType>, CompletableFuture<EventType>>,
+): EventRegistration<KeyType, EventType>? = registerAsyncUnhandled(priority, EventType::class.java, handler)
+
+inline fun <KeyType, reified EventType : IAsyncEvent<KeyType>> IEventRegistry.registerAsyncUnhandled(
+    priority: Short,
+    handler: Function<CompletableFuture<EventType>, CompletableFuture<EventType>>,
+): EventRegistration<KeyType, EventType>? = registerAsyncUnhandled(priority, EventType::class.java, handler)

--- a/src/main/kotlin/io/github/hytalekt/kytale/ext/JavaPluginExt.kt
+++ b/src/main/kotlin/io/github/hytalekt/kytale/ext/JavaPluginExt.kt
@@ -4,4 +4,9 @@ import com.hypixel.hytale.server.core.modules.interaction.interaction.config.Int
 import com.hypixel.hytale.server.core.plugin.JavaPlugin
 import com.hypixel.hytale.server.core.plugin.registry.CodecMapRegistry
 
+/**
+ * Returns the [Interaction] codec registry for this plugin
+ *
+ * @see com.hypixel.hytale.server.core.plugin.JavaPlugin.getCodecRegistry
+ */
 val JavaPlugin.interactionRegistry: CodecMapRegistry.Assets<Interaction, *> get() = this.getCodecRegistry(Interaction.CODEC)

--- a/src/main/kotlin/io/github/hytalekt/kytale/ext/JavaPluginExt.kt
+++ b/src/main/kotlin/io/github/hytalekt/kytale/ext/JavaPluginExt.kt
@@ -1,0 +1,7 @@
+package io.github.hytalekt.kytale.ext
+
+import com.hypixel.hytale.server.core.modules.interaction.interaction.config.Interaction
+import com.hypixel.hytale.server.core.plugin.JavaPlugin
+import com.hypixel.hytale.server.core.plugin.registry.CodecMapRegistry
+
+val JavaPlugin.interactionRegistry: CodecMapRegistry.Assets<Interaction, *> get() = this.getCodecRegistry(Interaction.CODEC)

--- a/src/main/kotlin/io/github/hytalekt/kytale/ext/LoggerExt.kt
+++ b/src/main/kotlin/io/github/hytalekt/kytale/ext/LoggerExt.kt
@@ -1,0 +1,34 @@
+package io.github.hytalekt.kytale.ext
+
+import com.google.common.flogger.AbstractLogger
+import com.google.common.flogger.LoggingApi
+import java.util.logging.Level
+
+/**
+ * Returns a logging API for the specified level, or null if disabled
+ *
+ * @param level The logging level to check
+ * @return The logging API if enabled, null otherwise
+ */
+fun <T : AbstractLogger<Api>, Api : LoggingApi<Api>> T.atLevelOrNull(level: Level): LoggingApi<Api>? = at(level).takeIf { it.isEnabled }
+
+/** Returns a SEVERE level logging API, or null if disabled */
+fun <T : AbstractLogger<Api>, Api : LoggingApi<Api>> T.atSevereOrNull(): LoggingApi<Api>? = atLevelOrNull(Level.SEVERE)
+
+/** Returns a WARNING level logging API, or null if disabled */
+fun <T : AbstractLogger<Api>, Api : LoggingApi<Api>> T.atWarningOrNull(): LoggingApi<Api>? = atLevelOrNull(Level.WARNING)
+
+/** Returns an INFO level logging API, or null if disabled */
+fun <T : AbstractLogger<Api>, Api : LoggingApi<Api>> T.atInfoOrNull(): LoggingApi<Api>? = atLevelOrNull(Level.INFO)
+
+/** Returns a CONFIG level logging API, or null if disabled */
+fun <T : AbstractLogger<Api>, Api : LoggingApi<Api>> T.atConfigOrNull(): LoggingApi<Api>? = atLevelOrNull(Level.CONFIG)
+
+/** Returns a FINE level logging API, or null if disabled */
+fun <T : AbstractLogger<Api>, Api : LoggingApi<Api>> T.atFineOrNull(): LoggingApi<Api>? = atLevelOrNull(Level.FINE)
+
+/** Returns a FINER level logging API, or null if disabled */
+fun <T : AbstractLogger<Api>, Api : LoggingApi<Api>> T.atFinerOrNull(): LoggingApi<Api>? = atLevelOrNull(Level.FINER)
+
+/** Returns a FINEST level logging API, or null if disabled */
+fun <T : AbstractLogger<Api>, Api : LoggingApi<Api>> T.atFinestOrNull(): LoggingApi<Api>? = atLevelOrNull(Level.FINEST)

--- a/src/main/kotlin/io/github/hytalekt/kytale/ext/VectorExt.kt
+++ b/src/main/kotlin/io/github/hytalekt/kytale/ext/VectorExt.kt
@@ -1,0 +1,353 @@
+package io.github.hytalekt.kytale.ext
+
+import com.hypixel.hytale.math.vector.Vector2d
+import com.hypixel.hytale.math.vector.Vector2i
+import com.hypixel.hytale.math.vector.Vector2l
+import com.hypixel.hytale.math.vector.Vector3d
+import com.hypixel.hytale.math.vector.Vector3f
+import com.hypixel.hytale.math.vector.Vector3i
+import com.hypixel.hytale.math.vector.Vector3l
+import com.hypixel.hytale.math.vector.Vector4d
+
+/** @see Vector2i.add */
+operator fun Vector2i.plus(other: Vector2i): Vector2i = clone().add(other)
+
+/** @see Vector2i.add */
+operator fun Vector2i.plusAssign(other: Vector2i) {
+    add(other)
+}
+
+/** @see Vector2i.subtract */
+operator fun Vector2i.minus(other: Vector2i): Vector2i = clone().subtract(other)
+
+/** @see Vector2i.subtract */
+operator fun Vector2i.minusAssign(other: Vector2i) {
+    subtract(other)
+}
+
+/** @see Vector2i.scale */
+operator fun Vector2i.times(other: Vector2i): Vector2i = clone().scale(other)
+
+/** @see Vector2i.scale */
+operator fun Vector2i.times(scalar: Int): Vector2i = clone().scale(scalar)
+
+/** @see Vector2i.scale */
+operator fun Vector2i.timesAssign(other: Vector2i) {
+    scale(other)
+}
+
+/** @see Vector2i.scale */
+operator fun Vector2i.timesAssign(scalar: Int) {
+    scale(scalar)
+}
+
+/** @see Vector2i.negate */
+operator fun Vector2i.unaryMinus(): Vector2i = clone().negate()
+
+/** Destructuring support for [Vector2i] */
+operator fun Vector2i.component1(): Int = x
+
+/** Destructuring support for [Vector2i] */
+operator fun Vector2i.component2(): Int = y
+
+/** @see Vector2d.add */
+operator fun Vector2d.plus(other: Vector2d): Vector2d = clone().add(other)
+
+/** @see Vector2d.add */
+operator fun Vector2d.plusAssign(other: Vector2d) {
+    add(other)
+}
+
+/** @see Vector2d.subtract */
+operator fun Vector2d.minus(other: Vector2d): Vector2d = clone().subtract(other)
+
+/** @see Vector2d.subtract */
+operator fun Vector2d.minusAssign(other: Vector2d) {
+    subtract(other)
+}
+
+/** @see Vector2d.scale */
+operator fun Vector2d.times(other: Vector2d): Vector2d = clone().scale(other)
+
+/** @see Vector2d.scale */
+operator fun Vector2d.times(scalar: Double): Vector2d = clone().scale(scalar)
+
+/** @see Vector2d.scale */
+operator fun Vector2d.timesAssign(other: Vector2d) {
+    scale(other)
+}
+
+/** @see Vector2d.scale */
+operator fun Vector2d.timesAssign(scalar: Double) {
+    scale(scalar)
+}
+
+/** @see Vector2d.negate */
+operator fun Vector2d.unaryMinus(): Vector2d = clone().negate()
+
+/** Destructuring support for [Vector2d] */
+operator fun Vector2d.component1(): Double = x
+
+/** Destructuring support for [Vector2d] */
+operator fun Vector2d.component2(): Double = y
+
+/** @see Vector2l.add */
+operator fun Vector2l.plus(other: Vector2l): Vector2l = clone().add(other)
+
+/** @see Vector2l.add */
+operator fun Vector2l.plusAssign(other: Vector2l) {
+    add(other)
+}
+
+/** @see Vector2l.subtract */
+operator fun Vector2l.minus(other: Vector2l): Vector2l = clone().subtract(other)
+
+/** @see Vector2l.subtract */
+operator fun Vector2l.minusAssign(other: Vector2l) {
+    subtract(other)
+}
+
+/** @see Vector2l.scale */
+operator fun Vector2l.times(other: Vector2l): Vector2l = clone().scale(other)
+
+/** @see Vector2l.scale */
+operator fun Vector2l.times(scalar: Long): Vector2l = clone().scale(scalar)
+
+/** @see Vector2l.scale */
+operator fun Vector2l.timesAssign(other: Vector2l) {
+    scale(other)
+}
+
+/** @see Vector2l.scale */
+operator fun Vector2l.timesAssign(scalar: Long) {
+    scale(scalar)
+}
+
+/** @see Vector2l.negate */
+operator fun Vector2l.unaryMinus(): Vector2l = clone().negate()
+
+/** Destructuring support for [Vector2l] */
+operator fun Vector2l.component1(): Long = x
+
+/** Destructuring support for [Vector2l] */
+operator fun Vector2l.component2(): Long = y
+
+/** @see Vector3i.add */
+operator fun Vector3i.plus(other: Vector3i): Vector3i = clone().add(other)
+
+/** @see Vector3i.add */
+operator fun Vector3i.plusAssign(other: Vector3i) {
+    add(other)
+}
+
+/** @see Vector3i.subtract */
+operator fun Vector3i.minus(other: Vector3i): Vector3i = clone().subtract(other)
+
+/** @see Vector3i.subtract */
+operator fun Vector3i.minusAssign(other: Vector3i) {
+    subtract(other)
+}
+
+/** @see Vector3i.scale */
+operator fun Vector3i.times(other: Vector3i): Vector3i = clone().scale(other)
+
+/** @see Vector3i.scale */
+operator fun Vector3i.times(scalar: Int): Vector3i = clone().scale(scalar)
+
+/** @see Vector3i.scale */
+operator fun Vector3i.timesAssign(other: Vector3i) {
+    scale(other)
+}
+
+/** @see Vector3i.scale */
+operator fun Vector3i.timesAssign(scalar: Int) {
+    scale(scalar)
+}
+
+/** @see Vector3i.negate */
+operator fun Vector3i.unaryMinus(): Vector3i = clone().negate()
+
+/** Destructuring support for [Vector3i] */
+operator fun Vector3i.component1(): Int = x
+
+/** Destructuring support for [Vector3i] */
+operator fun Vector3i.component2(): Int = y
+
+/** Destructuring support for [Vector3i] */
+operator fun Vector3i.component3(): Int = z
+
+/** @see Vector3l.add */
+operator fun Vector3l.plus(other: Vector3l): Vector3l = clone().add(other)
+
+/** @see Vector3l.add */
+operator fun Vector3l.plusAssign(other: Vector3l) {
+    add(other)
+}
+
+/** @see Vector3l.subtract */
+operator fun Vector3l.minus(other: Vector3l): Vector3l = clone().subtract(other)
+
+/** @see Vector3l.subtract */
+operator fun Vector3l.minusAssign(other: Vector3l) {
+    subtract(other)
+}
+
+/** @see Vector3l.scale */
+operator fun Vector3l.times(other: Vector3l): Vector3l = clone().scale(other)
+
+/** @see Vector3l.scale */
+operator fun Vector3l.times(scalar: Long): Vector3l = clone().scale(scalar)
+
+/** @see Vector3l.scale */
+operator fun Vector3l.timesAssign(other: Vector3l) {
+    scale(other)
+}
+
+/** @see Vector3l.scale */
+operator fun Vector3l.timesAssign(scalar: Long) {
+    scale(scalar)
+}
+
+/** @see Vector3l.negate */
+operator fun Vector3l.unaryMinus(): Vector3l = clone().negate()
+
+/** Destructuring support for [Vector3l] */
+operator fun Vector3l.component1(): Long = x
+
+/** Destructuring support for [Vector3l] */
+operator fun Vector3l.component2(): Long = y
+
+/** Destructuring support for [Vector3l] */
+operator fun Vector3l.component3(): Long = z
+
+/** @see Vector3d.add */
+operator fun Vector3d.plus(other: Vector3d): Vector3d = clone().add(other)
+
+/** @see Vector3d.add */
+operator fun Vector3d.plus(other: Vector3i): Vector3d = clone().add(other)
+
+/** @see Vector3d.add */
+operator fun Vector3d.plusAssign(other: Vector3d) {
+    add(other)
+}
+
+/** @see Vector3d.add */
+operator fun Vector3d.plusAssign(other: Vector3i) {
+    add(other)
+}
+
+/** @see Vector3d.subtract */
+operator fun Vector3d.minus(other: Vector3d): Vector3d = clone().subtract(other)
+
+/** @see Vector3d.subtract */
+operator fun Vector3d.minus(other: Vector3i): Vector3d = clone().subtract(other)
+
+/** @see Vector3d.subtract */
+operator fun Vector3d.minusAssign(other: Vector3d) {
+    subtract(other)
+}
+
+/** @see Vector3d.subtract */
+operator fun Vector3d.minusAssign(other: Vector3i) {
+    subtract(other)
+}
+
+/** @see Vector3d.scale */
+operator fun Vector3d.times(other: Vector3d): Vector3d = clone().scale(other)
+
+/** @see Vector3d.scale */
+operator fun Vector3d.times(scalar: Double): Vector3d = clone().scale(scalar)
+
+/** @see Vector3d.scale */
+operator fun Vector3d.timesAssign(other: Vector3d) {
+    scale(other)
+}
+
+/** @see Vector3d.scale */
+operator fun Vector3d.timesAssign(scalar: Double) {
+    scale(scalar)
+}
+
+/** @see Vector3d.negate */
+operator fun Vector3d.unaryMinus(): Vector3d = clone().negate()
+
+/** Destructuring support for [Vector3d] */
+operator fun Vector3d.component1(): Double = x
+
+/** Destructuring support for [Vector3d] */
+operator fun Vector3d.component2(): Double = y
+
+/** Destructuring support for [Vector3d] */
+operator fun Vector3d.component3(): Double = z
+
+/** @see Vector3f.add */
+operator fun Vector3f.plus(other: Vector3f): Vector3f = clone().add(other)
+
+/** @see Vector3f.add */
+operator fun Vector3f.plus(other: Vector3i): Vector3f = clone().add(other)
+
+/** @see Vector3f.add */
+operator fun Vector3f.plusAssign(other: Vector3f) {
+    add(other)
+}
+
+/** @see Vector3f.add */
+operator fun Vector3f.plusAssign(other: Vector3i) {
+    add(other)
+}
+
+/** @see Vector3f.subtract */
+operator fun Vector3f.minus(other: Vector3f): Vector3f = clone().subtract(other)
+
+/** @see Vector3f.subtract */
+operator fun Vector3f.minus(other: Vector3i): Vector3f = clone().subtract(other)
+
+/** @see Vector3f.subtract */
+operator fun Vector3f.minusAssign(other: Vector3f) {
+    subtract(other)
+}
+
+/** @see Vector3f.subtract */
+operator fun Vector3f.minusAssign(other: Vector3i) {
+    subtract(other)
+}
+
+/** @see Vector3f.scale */
+operator fun Vector3f.times(other: Vector3f): Vector3f = clone().scale(other)
+
+/** @see Vector3f.scale */
+operator fun Vector3f.times(scalar: Float): Vector3f = clone().scale(scalar)
+
+/** @see Vector3f.scale */
+operator fun Vector3f.timesAssign(other: Vector3f) {
+    scale(other)
+}
+
+/** @see Vector3f.scale */
+operator fun Vector3f.timesAssign(scalar: Float) {
+    scale(scalar)
+}
+
+/** @see Vector3f.negate */
+operator fun Vector3f.unaryMinus(): Vector3f = clone().negate()
+
+/** Destructuring support for [Vector3f] */
+operator fun Vector3f.component1(): Float = x
+
+/** Destructuring support for [Vector3f] */
+operator fun Vector3f.component2(): Float = y
+
+/** Destructuring support for [Vector3f] */
+operator fun Vector3f.component3(): Float = z
+
+/** Destructuring support for [Vector4d] */
+operator fun Vector4d.component1(): Double = x
+
+/** Destructuring support for [Vector4d] */
+operator fun Vector4d.component2(): Double = y
+
+/** Destructuring support for [Vector4d] */
+operator fun Vector4d.component3(): Double = z
+
+/** Destructuring support for [Vector4d] */
+operator fun Vector4d.component4(): Double = w


### PR DESCRIPTION
Adds extensions for the following:

- Vector2d, Vector2i, Vector2l, Vector3d, Vector3f, Vector3i, Vector3l, Vector4d
  - Operator functions
  - Destructuring
- AbstractLogger
  - atLevelOrNull & at<Level>OrNull (returns null if disabled)
- JavaPlugin
  - interactionRegistry
- IEventRegistry
  - inline reified functions
- EventBus
  - inline reified functions for getRegistry() & getSyncRegistry()

TODO:
- [x] Base implementation
- [x] KDoc
- [x] Unit tests (unneeded for these probably)
- [x] Examples